### PR TITLE
Dependency Split Development & Production / Tests Workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Check out the repository
@@ -24,8 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install sphinx sphinxawesome_theme
-        pip install -e .
+        pip install -e .[docs]
 
     - name: Clean old build files
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Run tests
+      run: |
+        pytest 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,16 +22,21 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-    "sphinx>=7.0.0",
-    "sphinx-rtd-theme>=2.0.0",
-    "sphinx-autodoc-typehints>=1.25.0",
     "IPython>=8.0.0",
+    "ipykernel>=6.0.0",
+    "pytest>=7.0.0",
+    "folium>=0.14.0",
+    "pandas>=2.0.0",
+    "matplotlib>=3.0.0",
+    "plotly>=5.0.0",
+    "seaborn>=0.12.0",
 ]
 docs = [
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=2.0.0",
     "sphinx-autodoc-typehints>=1.25.0",
     "IPython>=8.0.0",
+    "sphinxawesome_theme",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,15 @@ classifiers = [
 ]
 keywords = ["snowpit", "caaml", "snowpilot"]
 requires-python = ">=3.7"
-dependencies = [
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=2.0.0",
     "sphinx-autodoc-typehints>=1.25.0",
     "IPython>=8.0.0",
 ]
-
-[project.optional-dependencies]
 docs = [
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=2.0.0",


### PR DESCRIPTION
1. Split dependencies between development and production so that sphinx does not end up in production package.
2. Created workflow that runs unittests on Main Push.
3. Modified Docs workflow to have write permission -> to gh-pages.